### PR TITLE
9-2 ランキング棒グラフのAPI連携 APIのルーティングの追加

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -21,4 +21,5 @@ Route::group(['middleware' => ['api']], function () {
     Route::get('information', 'Api\InformationController@index');
     Route::get('category', 'Api\CategoryController@index');
     Route::get('quiz', 'Api\QuizController@index');
+    Route::get('ranking', 'Api\RankingController@index');
 });


### PR DESCRIPTION
対応するURLと呼び出すコントローラーを設定するため、laravel_vue_quiz/routes/api.phpを編集しました。

■APIのルーティングが設定できていることを確認しました。
<img width="627" alt="スクリーンショット 2020-12-17 23 30 34" src="https://user-images.githubusercontent.com/63224224/102501051-55a97700-40c0-11eb-9808-1fea220080cd.png">
