### PR TITLE
9-2　ランキング棒グラフのAPI連携　APIの呼び出し　Home.vueを編集

### DIFF
--- a/resources/js/components/page/Home.vue
+++ b/resources/js/components/page/Home.vue
@@ -16,12 +16,13 @@
                         </h2>
                         <form>
                             <label v-for="(cate, index) in category" :key="index">
-                                <input type="checkbox" v-model="categories" :value="cate.id" />{{cate.name}}&ensp;
+                                <input type="checkbox" v-model="categories" :value="cate.id" checked />
+                                {{cate.name}}&ensp;
                             </label>
-                            <div >
+                            <div>
                                 全項目チェック
-                                <button type="button" name="check_all" id="check-all" value="1">ON</button>
-                                <button type="button" name="check_all_off" id="check-all-off" value="1">OFF</button>
+                                <button type="button" name="check_all" value="1">ON</button>
+                                <button type="button" name="check_all_off" value="1">OFF</button>
                             </div>
                             <button type="submit" class="btn btn-primary" @click.stop.prevent="goQuiz()">出題開始</button>
                         </form>
@@ -32,17 +33,19 @@
                         </h2>
                         <div>
                             <label>
-                                <input class="ranking-radio" type="radio" name="ranking-radio" value="1" checked />総合
+                                <input class="ranking-radio" type="radio" v-model="rankingType" value="1" />総合
                             </label>
                             <label>
-                                <input class="ranking-radio" type="radio" name="ranking-radio" value="2" />今月
+                                <input class="ranking-radio" type="radio" v-model="rankingType" value="2" />今月
                             </label>
                             <label>
-                                <input class="ranking-radio" type="radio" name="ranking-radio" value="3" />今週
+                                <input class="ranking-radio" type="radio" v-model="rankingType" value="3" />今週
                             </label>
                         </div>
                         <div class="home_quiz__ranking-chart">
-                            <bar-chart></bar-chart>
+                            <bar-chart :chartData="total" ref="totalChart" v-show="rankingType === '1'"></bar-chart>
+                            <bar-chart :chartData="month" ref="monthChart" v-show="rankingType === '2'"></bar-chart>
+                            <bar-chart :chartData="week" ref="weekChart" v-show="rankingType === '3'"></bar-chart>
                         </div>
                     </section>
                     <section class="home__notice">
@@ -75,6 +78,11 @@ export default {
             categories: [1],
             information: [],
             category: [],
+            rankingAlldata: {},
+            week: {},
+            month: {},
+            total: {},
+            rankingType: "1",
         };
     },
     mounted() {
@@ -84,11 +92,52 @@ export default {
         this.$http.get("/api/information").then(response => {
             this.information = response.data;
         });
+        this.$http.get("/api/ranking").then(response => {
+            this.rankingAlldata = response.data;
+            this.setRanking();
+        });
     },
     methods: {
         goQuiz() {
             this.$router.push("/quiz?categories=" + this.categories);
-        }
+        },
+        setRanking() {
+            this.week = Object.assign({}, this.week, {
+                labels: this.rankingAlldata.weekRankingData.name,
+                datasets: [
+                    {
+                        label: ["最高得点率"],
+                        backgroundColor: "rgba(0, 170, 248, 0.47)",
+                        data: this.rankingAlldata.weekRankingData.percentage_correct_answer
+                    }
+                ]
+            });
+            this.month = Object.assign({}, this.month, {
+                labels: this.rankingAlldata.monthRankingData.name,
+                datasets: [
+                    {
+                        label: ["最高得点率"],
+                        backgroundColor: "rgba(0, 170, 248, 0.47)",
+                        data: this.rankingAlldata.monthRankingData.percentage_correct_answer
+                    }
+                ]
+            });
+            this.total = Object.assign({}, this.total, {
+                labels: this.rankingAlldata.totalRankingData.name,
+                datasets: [
+                    {
+                        label: ["最高得点率"],
+                        backgroundColor: "rgba(0, 170, 248, 0.47)",
+                        data: this.rankingAlldata.totalRankingData.percentage_correct_answer
+                    }
+                ]
+            });
+            this.$nextTick(() => {
+                this.$refs.totalChart.renderBarChart();
+                this.$refs.monthChart.renderBarChart();
+                this.$refs.weekChart.renderBarChart();
+            });
+        },
     }
 };
 </script>


### PR DESCRIPTION
APIの呼び出しにて、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。

■ランキング棒グラフが描画されることを確認しました。

・総合
<img width="959" alt="スクリーンショット 2020-12-18 12 40 27" src="https://user-images.githubusercontent.com/63224224/102572089-87f1bd80-412e-11eb-8a63-d4147b4ab47b.png">

・今月
<img width="963" alt="スクリーンショット 2020-12-18 12 40 37" src="https://user-images.githubusercontent.com/63224224/102572101-8e803500-412e-11eb-93e2-c028fe01b456.png">

・今週
<img width="949" alt="スクリーンショット 2020-12-18 12 40 46" src="https://user-images.githubusercontent.com/63224224/102572108-96d87000-412e-11eb-8ba1-d3f484fdc0c3.png">
