### PR TITLE
9-5　マイページの作成 -API認証の連携- 正解率推移の折れ線グラフ導入

### DIFF
--- a/resources/js/components/page/Mypage.vue
+++ b/resources/js/components/page/Mypage.vue
@@ -8,7 +8,7 @@
                             <img class="mypage__logo" src="/images/mypage-icon.png" />マイページ
                         </h2>
                         <h3 v-if="changeCorrectRatioData.length !== 0">直近{{changeCorrectRatioData.percentage_correct_answer.length }}回の正解率推移</h3>
-                        <canvas></canvas>
+                        <line-chart :chartData="lineChartData" ref="chart"></line-chart>
                     </section>
                 </article>
                 <the-sidebar></the-sidebar>
@@ -19,19 +19,35 @@
 
 <script>
 import TheSidebar from "../layout/TheSidebar";
+import LineChart from "../module/LineChart";
 export default {
     components: {
-        TheSidebar
+        TheSidebar,
+        LineChart
     },
     data() {
         return {
-            changeCorrectRatioData: []
+            changeCorrectRatioData: [],
+            lineChartData: {}
         };
     },
     mounted() {
         this.$http.get("/api/mypage").then(response => {
             this.changeCorrectRatioData = response.data;
-            console.log(this.changeCorrectRatioData);
+            this.lineChartData = Object.assign({}, this.lineChartData, {
+                labels: this.changeCorrectRatioData.created_at,
+                datasets: [
+                    {
+                        label: ["最高得点率"],
+                        backgroundColor: "rgba(0, 170, 248, 0.47)",
+                        borderColor: "rgba(0, 170, 248, 1)",
+                        data: this.changeCorrectRatioData.percentage_correct_answer
+                    }
+                ]
+            });
+            this.$nextTick(() => {
+                this.$refs.chart.renderLineChart();
+            });
         });
     }
 };


### PR DESCRIPTION
正答率推移の折れ線グラフを導入するため、
laravel_vue_quiz/resources/js/components/page/Mypage.vueを編集しました。


■ログイン後のマイページで、折れ線グラフが表示されていることを確認しました。
<img width="1042" alt="スクリーンショット 2020-12-20 21 58 58" src="https://user-images.githubusercontent.com/63224224/102713896-9991bb80-430e-11eb-9d8b-7ff273c7ccc9.png">
