### PR TITLE
9-7　キーワード画面の作成 -API連携- 同一ルーティングでのSPAデータの更新

### DIFF
--- a/resources/js/components/page/keyword.vue
+++ b/resources/js/components/page/keyword.vue
@@ -28,20 +28,29 @@ import TheSidebar from "../layout/TheSidebar";
 
 export default {
     components: {
-        TheSidebar,
+        TheSidebar
     },
     data() {
         return {
             keyword: [],
-            initial : '',
-        }
+            initial: ""
+        };
     },
     mounted() {
-        const initial = this.$route.query.initial;
-        this.initial = initial;
-        this.$http.get(`/api/keyword?initial=${initial}`).then(response => {
-            this.keyword = response.data;
-        });
+        this.initial = this.$route.query.initial;
+        this.setkeyword(this.initial);
+    },
+    methods: {
+        setkeyword() {
+            this.$http.get(`/api/keyword?initial=${this.initial}`).then(response => {
+                this.keyword = response.data;
+            });
+        }
+    },
+    beforeRouteUpdate(to, from, next) {
+        next();
+        this.initial = this.$route.query.initial;
+        this.setkeyword(this.initial);
     }
 };
 </script>


### PR DESCRIPTION
Vue.jsのルーティング自体が変わらなくても、データの更新を行うよう設定するため、
laravel_vue_quiz/resources/js/components/page/Keyword.vueを編集しました。

■別のキーワードリンクをクリックして、SPA遷移を実行し、キーワードリンクが確認できることを確認しました。

https://user-images.githubusercontent.com/63224224/102716151-4d01ac80-431d-11eb-8663-f450e9064cb2.mov

