### PR TITLE
10-1　クイズ画面の調整 vue-loading-overlayの実装

### DIFF
--- a/resources/js/components/page/Quiz.vue
+++ b/resources/js/components/page/Quiz.vue
@@ -107,9 +107,11 @@ export default {
     },
     mounted() {
         const categories = this.$route.query.categories;
+        const loader = this.$loading.show();
         this.$http.get(`/api/quiz?categories=${categories}`).then(response => {
             this.quizData = response.data;
             this.findNextQuiz(0);
+            loader.hide();
         });
     },
     methods: {


### PR DESCRIPTION
vue-loading-overlayを呼び出すため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。

■クイズ画面を確認し、再度読み込みをしてローディング画面が映ることを確認しました。

https://user-images.githubusercontent.com/63224224/102786589-1db57300-43e3-11eb-94b3-880ec4119b8f.mov

