### PR TITLE
10-1　クイズ画面の調整 例外処理を追加

### DIFF
--- a/resources/js/components/page/Quiz.vue
+++ b/resources/js/components/page/Quiz.vue
@@ -74,7 +74,7 @@
                 <the-sidebar></the-sidebar>
             </div>
         </main>
-        <the-modal :correctPercentageObject="correctPercentageObject" ref="modal" ></the-modal>
+        <the-modal :correctPercentageObject="correctPercentageObject" ref="modal"></the-modal>
     </div>
 </template>
 
@@ -108,11 +108,22 @@ export default {
     mounted() {
         const categories = this.$route.query.categories;
         const loader = this.$loading.show();
-        this.$http.get(`/api/quiz?categories=${categories}`).then(response => {
-            this.quizData = response.data;
-            this.findNextQuiz(0);
-            loader.hide();
-        });
+        this.$http
+            .get(`/api/quiz?categories=${categories}`)
+            .then(response => {
+                this.quizData = response.data;
+                if (this.quizData.length < 10) {
+                    alert("クイズ10問以下のため、初期画面に戻ります。カテゴリーを選択し直してください");
+                    location.href = "/";
+                } else {
+                    this.findNextQuiz(0);
+                    loader.hide();
+                }
+            })
+            .catch(error => {
+                alert("クイズの読み込みに失敗したため、初期画面に戻ります");
+                location.href = "/";
+            });
     },
     methods: {
         goAnswer(selectAnswerNum) {


### PR DESCRIPTION
laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集して、二つの例外処理を追加しました。

・例外処理を追加し、API読み込みができなかった場合は、URL「/」に戻すように設定。
・API読み込み後にクイズが10問より少ない場合は、アラートを出してURL「/」に戻すように設定。

■クイズ画面を開いたときに例外処理が実装されていることを確認しました。

https://user-images.githubusercontent.com/63224224/102795401-1ba5e100-43f0-11eb-8a6b-0c45e25cd654.mov

