### PR TITLE
11-3 Laravel-Adminのカスタマイズ -クイズ・回答の管理の実装- QuizControllerの編集（表示機能のカスタマイズ）

### DIFF
--- a/app/Admin/Controllers/QuizController.php
+++ b/app/Admin/Controllers/QuizController.php
@@ -3,6 +3,8 @@
 namespace App\Admin\Controllers;
 
 use App\Quiz;
+use App\Category;
+use App\Answer;
 use Encore\Admin\Controllers\AdminController;
 use Encore\Admin\Form;
 use Encore\Admin\Grid;
@@ -10,12 +12,15 @@ use Encore\Admin\Show;
 
 class QuizController extends AdminController
 {
+
+
     /**
      * Title for current resource.
      *
      * @var string
      */
-    protected $title = 'Quiz';
+    protected $title = 'App\Quiz';
+
 
     /**
      * Make a grid builder.
@@ -24,13 +29,16 @@ class QuizController extends AdminController
      */
     protected function grid()
     {
-        $grid = new Grid(new Quiz());
+        $grid = new Grid(new Quiz);
 
         $grid->column('id', __('Id'));
         $grid->column('title', __('Title'));
+        $grid->column('answer.answer_1',  __('Answer 1'));
+        $grid->column('answer.answer_2',  __('Answer 2'));
+        $grid->column('answer.answer_3',  __('Answer 3'));
+        $grid->column('answer.answer_4',  __('Answer 4'));
+        $grid->column('category.name', __('Categories name'));
         $grid->column('image_src', __('Image src'));
-        $grid->column('answers_id', __('Answers id'));
-        $grid->column('categories_id', __('Categories id'));
         $grid->column('created_at', __('Created at'));
         $grid->column('updated_at', __('Updated at'));
 
@@ -46,7 +54,6 @@ class QuizController extends AdminController
     protected function detail($id)
     {
         $show = new Show(Quiz::findOrFail($id));
-
         $show->field('id', __('Id'));
         $show->field('title', __('Title'));
         $show->field('image_src', __('Image src'));
@@ -65,8 +72,8 @@ class QuizController extends AdminController
      */
     protected function form()
     {
-        $form = new Form(new Quiz());
 
+        $form = new Form(new Quiz);
         $form->textarea('title', __('Title'));
         $form->text('image_src', __('Image src'));
         $form->number('answers_id', __('Answers id'));


### PR DESCRIPTION
表示機能のカスタマイズをするため、laravel_vue_quiz/app/Admin/Controllers/QuizController.php を編集しました。

■クイズ管理画面の表示がカスタマイズされていることを確認しました。
<img width="1082" alt="スクリーンショット 2020-12-22 12 11 12" src="https://user-images.githubusercontent.com/63224224/102845276-8d157c00-4450-11eb-91eb-d5726acee7e7.png">
