### PR TITLE
11-3 Laravel-Adminのカスタマイズ -クイズ・回答の管理の実装- 削除機能のカスタマイズ-Quizと連動してAnswerも削除する-

### DIFF
--- a/app/Quiz.php
+++ b/app/Quiz.php
@@ -18,4 +18,13 @@ class Quiz extends Model
     {
         return $this->hasOne('App\Category', 'id', 'categories_id');
     }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function ($answer_model) {
+            $answer_model->answer()->delete();
+        });
+    }
 }


### PR DESCRIPTION
モデルのリレーションでQuizを削除した時、紐付くAnswerも削除する機能を実装するため、laravel_vue_quiz/app/Quiz.phpを編集しました。